### PR TITLE
修改 Bug ：MySQL 环境下无法使用 123456 作为密码登录

### DIFF
--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -197,7 +197,7 @@ INSERT INTO stockpile
 VALUES (8, 30, 0, 8);
 
 INSERT INTO account
-VALUES (1, 'icyfenix', '$2a$10$LTqKTXXRb26SYG3MvFG1UuKhMgc/i6IbUl2RgApiWd39y1EqlXbD6', '周志明', '', '18888888888',
+VALUES (1, 'icyfenix', '$2a$10$iIim4LtpT2yjxU2YVNDuO.yb1Z2lq86vYBZleAeuIh2aFXjyoMCM.', '周志明', '', '18888888888',
         'icyfenix@gmail.com', '唐家湾港湾大道科技一路3号远光软件股份有限公司');
 INSERT INTO wallet
 VALUES (1, 100, 1);


### PR DESCRIPTION
src/main/resources/db/hsqldb/data.sql 文件中的登录密码与 src/main/resources/db/mysql/data.sql 文件中的登录密码不一致，MySQL 这边的是错的，改成跟 HSQLDB 一样了。